### PR TITLE
SAF-28: Add logging

### DIFF
--- a/.idea/runConfigurations/Run.xml
+++ b/.idea/runConfigurations/Run.xml
@@ -10,6 +10,7 @@
     <option name="backtrace" value="SHORT" />
     <envs>
       <env name="SW_DB_URI" value="mongodb://localhost:42781" />
+      <env name="RUST_LOG" value="info" />
     </envs>
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,8 @@ version = "0.1.0"
 dependencies = [
  "bson",
  "config",
+ "env_logger",
+ "log",
  "mongodb",
  "serde 1.0.130",
  "tokio",
@@ -49,6 +51,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -256,6 +269,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -501,6 +527,12 @@ name = "httpdate"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1366,6 +1398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,6 +1888,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Follow this section if you need to make code changes.
 2. Set environmental variables (assumes PowerShell).
    ```
    $env:SW_DB_URI="mongodb://localhost:42781"
+   $env:RUST_LOG="info"
    ```
 3. Build and run.
    ```

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2018"
 [dependencies]
 bson = "2.0"
 config = "0.11"
+env_logger = "0.9"
+log = "0.4"
 mongodb = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.13", features = ["full"] }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -15,6 +15,7 @@ struct ViewCount {
 
 #[tokio::main]
 async fn main() {
+    env_logger::init();
     let settings = Settings::read();
     let db = Client::with_uri_str(&settings.db_uri)
         .await

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       dockerfile: "api.Dockerfile"
     environment:
       SW_DB_URI: "mongodb://mongo:27017"
+      RUST_LOG: "info"
     ports:
       - "3001:3001"
     depends_on:


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-28

This pull request:
- Adds logging libraries to the API.
- Sets the log level to "info" which includes information about server startup and incoming HTTP requests.