### PR TITLE
SAF-76: Fix forbidden filter matching

### DIFF
--- a/api/src/v1/mod.rs
+++ b/api/src/v1/mod.rs
@@ -56,37 +56,47 @@ pub trait ResourceApi {
     }
 
     fn get(&self) -> BoxedFilter<(Box<dyn Reply>,)> {
-        forbidden_filter(self.collection_name(), warp::get())
+        warp::path(self.collection_name())
+            .and(warp::get())
+            .and(warp::path::param())
+            .map(|_: String| Box::new(StatusCode::FORBIDDEN) as Box<dyn Reply>)
+            .boxed()
     }
 
     fn list(&self) -> BoxedFilter<(Box<dyn Reply>,)> {
-        forbidden_filter(self.collection_name(), warp::get())
+        warp::path(self.collection_name())
+            .and(warp::get())
+            .map(|| Box::new(StatusCode::FORBIDDEN) as Box<dyn Reply>)
+            .boxed()
     }
 
     fn create(&self) -> BoxedFilter<(Box<dyn Reply>,)> {
-        forbidden_filter(self.collection_name(), warp::post())
+        warp::path(self.collection_name())
+            .and(warp::post())
+            .map(|| Box::new(StatusCode::FORBIDDEN) as Box<dyn Reply>)
+            .boxed()
     }
 
     fn update(&self) -> BoxedFilter<(Box<dyn Reply>,)> {
-        forbidden_filter(self.collection_name(), warp::patch())
+        warp::path(self.collection_name())
+            .and(warp::patch())
+            .map(|| Box::new(StatusCode::FORBIDDEN) as Box<dyn Reply>)
+            .boxed()
     }
 
     fn delete(&self) -> BoxedFilter<(Box<dyn Reply>,)> {
-        forbidden_filter(self.collection_name(), warp::delete())
+        warp::path(self.collection_name())
+            .and(warp::delete())
+            .map(|| Box::new(StatusCode::FORBIDDEN) as Box<dyn Reply>)
+            .boxed()
     }
 
     fn replace(&self) -> BoxedFilter<(Box<dyn Reply>,)> {
-        forbidden_filter(self.collection_name(), warp::put())
+        warp::path(self.collection_name())
+            .and(warp::put())
+            .map(|| Box::new(StatusCode::FORBIDDEN) as Box<dyn Reply>)
+            .boxed()
     }
-}
-
-fn forbidden_filter(
-    collection_name: String,
-    method: impl Filter<Extract = (), Error = Rejection> + Copy + Send + Sync + 'static,
-) -> BoxedFilter<(Box<dyn Reply>,)> {
-    warp::path(collection_name)
-        .and(method.map(|| Box::new(StatusCode::FORBIDDEN) as Box<dyn Reply>))
-        .boxed()
 }
 
 pub trait ResourceOperation {


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-76

This pull request fixes the default resource filters so that 'get' requests do not incorrectly match and swallow 'list' requests.