### PR TITLE
SAF-157: Sort locations by timestamp

### DIFF
--- a/api/src/graphql/company.rs
+++ b/api/src/graphql/company.rs
@@ -10,7 +10,7 @@ use futures_util::TryStreamExt;
 use juniper::{FieldResult, ID};
 
 #[derive(Clone, From)]
-pub struct Company(company::Company);
+pub struct Company(pub company::Company);
 
 #[derive(juniper::GraphQLInputObject)]
 pub struct CompanyInput {

--- a/api/src/graphql/location_reading.rs
+++ b/api/src/graphql/location_reading.rs
@@ -7,7 +7,7 @@ use futures_util::TryStreamExt;
 use juniper::FieldResult;
 
 #[derive(Clone, From)]
-pub struct LocationReading(location_reading::LocationReading);
+pub struct LocationReading(pub location_reading::LocationReading);
 
 #[juniper::graphql_object(context = Context)]
 impl LocationReading {
@@ -29,11 +29,13 @@ impl LocationReading {
 }
 
 pub async fn list(context: &Context) -> FieldResult<Vec<LocationReading>> {
-    Ok(context
+    let mut vec: Vec<LocationReading> = context
         .location_reading_repo
         .find(&Default::default())
         .await?
         .map_ok(Into::into)
         .try_collect()
-        .await?)
+        .await?;
+    vec.sort_by_key(|l| l.0.timestamp);
+    Ok(vec)
 }

--- a/api/src/graphql/user_account.rs
+++ b/api/src/graphql/user_account.rs
@@ -7,7 +7,7 @@ use futures_util::TryStreamExt;
 use juniper::{FieldResult, ID};
 
 #[derive(Clone, From)]
-pub struct UserAccount(user_account::UserAccount);
+pub struct UserAccount(pub user_account::UserAccount);
 
 #[derive(juniper::GraphQLInputObject)]
 pub struct UserAccountInput {


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-157

This pull request:

- Sorts locations by timestamp in ascending order in GraphQL responses.