### PR TITLE
SAF-344: Filter out hidden location readings

### DIFF
--- a/api/src/repo/location_reading.rs
+++ b/api/src/repo/location_reading.rs
@@ -102,6 +102,7 @@ impl LocationReadingRepo for MongoLocationReadingRepo {
         filter: LocationReadingFilter,
     ) -> anyhow::Result<Box<dyn ItemStream<LocationReading>>> {
         let mut mongo_filter = Document::new();
+        mongo_filter.insert("hidden", filter::not_true());
         mongo_filter.insert_opt("person_id", filter::one_of(filter.person_ids));
         mongo_filter.insert_opt(
             "timestamp",

--- a/api/src/repo/mongo_util.rs
+++ b/api/src/repo/mongo_util.rs
@@ -105,4 +105,8 @@ pub mod filter {
     pub fn one_of<T: Into<Bson>>(values: Option<Vec<T>>) -> Option<Bson> {
         values.map(|v| (bson::doc! { "$in":  v }).into())
     }
+
+    pub fn not_true() -> Bson {
+        (bson::doc! { "$ne":  true }).into()
+    }
 }


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-344

This pull request makes it such that:
- Location readings marked as hidden are not included in API responses.