### PR TITLE
SAF-358: Allow authorization header in CORS

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -103,6 +103,7 @@ fn cors() -> Cors {
             "Access-Control-Request-Headers",
             "User-Agent",
             "Sec-Fetch-Mode",
+            "Authorization",
         ])
         .allow_methods(vec!["POST", "GET"])
         .build()


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-358

This pull request makes it such that:

- The Authorization header is allowed in CORS.