### PR TITLE
SAF-389: Hide logged off incidents

### DIFF
--- a/api/src/repo/incident.rs
+++ b/api/src/repo/incident.rs
@@ -116,6 +116,7 @@ impl IncidentRepo for MongoIncidentRepo {
         let mut mongo_query = Document::new();
         mongo_query.insert("_id", &db_incident.id);
         mongo_query.insert("hidden", filter::not_true());
+        mongo_query.insert("type", filter::not_hidden_incident());
         let res = self
             .collection()
             .replace_one(mongo_query, db_incident, None)
@@ -128,6 +129,7 @@ impl IncidentRepo for MongoIncidentRepo {
         let mut mongo_filter = Document::new();
         mongo_filter.insert("_id", id);
         mongo_filter.insert("hidden", filter::not_true());
+        mongo_filter.insert("type", filter::not_hidden_incident());
         Ok(self
             .collection()
             .find_one(mongo_filter, None)
@@ -138,6 +140,7 @@ impl IncidentRepo for MongoIncidentRepo {
     async fn find(&self, filter: IncidentFilter) -> anyhow::Result<Box<dyn ItemStream<Incident>>> {
         let mut mongo_filter = Document::new();
         mongo_filter.insert("hidden", filter::not_true());
+        mongo_filter.insert("type", filter::not_hidden_incident());
         mongo_filter.insert_opt("person_id", filter::one_of(filter.person_ids));
         mongo_filter.insert_opt(
             "timestamp",
@@ -157,6 +160,7 @@ impl IncidentRepo for MongoIncidentRepo {
         let mut mongo_query = Document::new();
         mongo_query.insert("_id", id);
         mongo_query.insert("hidden", filter::not_true());
+        mongo_query.insert("type", filter::not_hidden_incident());
         let res = self
             .collection()
             .delete_one(mongo_query, None)

--- a/api/src/repo/incident_stats.rs
+++ b/api/src/repo/incident_stats.rs
@@ -56,6 +56,7 @@ impl IncidentStatsRepo for MongoIncidentStatsRepo {
     ) -> anyhow::Result<Box<dyn ItemStream<IncidentStats>>> {
         let mut mongo_filter = Document::new();
         mongo_filter.insert("hidden", filter::not_true());
+        mongo_filter.insert("type", filter::not_hidden_incident());
         mongo_filter.insert_opt("person_id", filter::one_of(filter.person_ids));
         mongo_filter.insert_opt(
             "timestamp",

--- a/api/src/repo/mongo_util.rs
+++ b/api/src/repo/mongo_util.rs
@@ -5,6 +5,8 @@ use mongodb::options::FindOptions;
 use mongodb::Collection;
 use serde::de::DeserializeOwned;
 
+pub const HIDDEN_INCIDENTS: [&str; 1] = ["Logged off"];
+
 pub trait InsertOpt {
     fn insert_opt<KT: Into<String>, BT: Into<Bson>>(
         &mut self,
@@ -86,6 +88,7 @@ impl FromDeletedCount for DeleteResult {
 }
 
 pub mod filter {
+    use crate::repo::mongo_util::HIDDEN_INCIDENTS;
     use bson::{Bson, Document};
 
     pub fn clamp<T: Into<Bson>>(
@@ -108,5 +111,9 @@ pub mod filter {
 
     pub fn not_true() -> Bson {
         (bson::doc! { "$ne":  true }).into()
+    }
+
+    pub fn not_hidden_incident() -> Bson {
+        (bson::doc! { "$nin":  HIDDEN_INCIDENTS.to_vec() }).into()
     }
 }


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-389

This pull request makes it such that:

- "Logged off" incidents are not included in API responses.
- "Logged off" incidents are not considered for incident statistics.

We do not consider "Logged off" to be a genuine incident worth attention.