### PR TITLE
SAF-432: Hide zero density gas readings

### DIFF
--- a/api/src/repo/gas_reading.rs
+++ b/api/src/repo/gas_reading.rs
@@ -114,6 +114,7 @@ impl GasReadingRepo for MongoGasReadingRepo {
     ) -> anyhow::Result<Box<dyn ItemStream<GasReading>>> {
         let mut mongo_filter = Document::new();
         mongo_filter.insert("hidden", filter::not_true());
+        mongo_filter.insert("density", filter::not(0));
         mongo_filter.insert_opt("person_id", filter::one_of(filter.person_ids));
         mongo_filter.insert_opt(
             "timestamp",

--- a/api/src/repo/mongo_util.rs
+++ b/api/src/repo/mongo_util.rs
@@ -110,7 +110,11 @@ pub mod filter {
     }
 
     pub fn not_true() -> Bson {
-        (bson::doc! { "$ne":  true }).into()
+        not(true)
+    }
+
+    pub fn not<T: Into<Bson>>(value: T) -> Bson {
+        (bson::doc! { "$ne":  value.into() }).into()
     }
 
     pub fn not_hidden_incident() -> Bson {


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-432

This pull request makes it such that:

- Gas readings with a density of zero are hidden.